### PR TITLE
Make mysql JDBC optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/data-copier/
+.idea/

--- a/data-copier/.gitignore
+++ b/data-copier/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /.settings/
 /target/
+data-copier.iml

--- a/data-copier/pom.xml
+++ b/data-copier/pom.xml
@@ -9,6 +9,7 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>6.0.5</version>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
This commit:

* adds support for development from IntelliJ
* makes mysql JDBC optional so anyone can reuse the code with only the needed dependencies